### PR TITLE
fix: change alarm name for blue stack

### DIFF
--- a/lib/blue-green-using-ecs-stack.ts
+++ b/lib/blue-green-using-ecs-stack.ts
@@ -213,8 +213,8 @@ export class BlueGreenUsingEcsStack extends cdk.Stack {
             statistic: cloudWatch.Statistic.SUM,
             period: Duration.minutes(1)
         });
-        const blueGroupAlarm = new cloudWatch.Alarm(this, "blue5xxErrors", {
-            alarmName: "Blue_5xx_Alarm",
+        const blueGroupAlarm = new cloudWatch.Alarm(this, "blue4xxErrors", {
+            alarmName: "Blue_4xx_Alarm",
             alarmDescription: "CloudWatch Alarm for the 4xx errors of Blue target group",
             metric: blue4xxMetric,
             threshold: 1,


### PR DESCRIPTION
This is a minor change but during the workshop, we change the Nginx in order to produce 404 errors. For this reason, I think that the name of the alert should be `Blue_4XX_Alarm`